### PR TITLE
Release v1.4.0

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -72,7 +72,8 @@ class Bot(commands.Cog):
         brief="Shows version.",
         description=(
             "Shows the version Ailie is currently bearing. "
-            + "The version uses the format `x.y.z` where `x` is for major updates, "
+            + "The version uses the format `x.y.z` where "
+            + "`x` is for major updates, "
             + "`y` is for minor updates, and `z` is for bug fixes."
         ),
     )
@@ -90,7 +91,7 @@ class Bot(commands.Cog):
         db_ailie.disconnect()
 
         # Change upon version update
-        version = "1.3.4"
+        version = "1.4.0"
 
         # Mimic loading animation
         msg = await ctx.send(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.7.4.post0
 async-timeout==3.0.1
 attrs==20.3.0
 chardet==4.0.0
-discord.py==1.6.0
+discord.py==1.7.2
 idna==3.1
 multidict==5.1.0
 psycopg2==2.8.6


### PR DESCRIPTION
**Changelogs v1.4.0**

### Arena

- Turn-based arena. Each player can either `ATTACK` to attack, `WEAPON SKILL` to stun opponent, `CHAIN SKILL` to hit a stunned opponent (can only be used on stunned opponent), `DODGE` to increase speed so opponent may miss their attacks, and `FLEE` to surrender.
- Upon completion, winner will gain 25 Trophies, meanwhile, loser will lose 10 Trophies. Winner will also have his or her hero that is used gain 50 EXP, meanwhile, the loser's will gain 30 EXP. Not just that, winner will also gain 500 gems.
- NOTE: `WEAPON SKILL` in arena right now is simply an option to stun opponent so you can `CHAIN SKILL` them afterwards. However, the real (mostly) effects of Exclusive Weapon Skill will be implemented soon.
- Trophies can also be viewed like how Gems are viewed (`a;rank`, `a;trophy`).

### Levels, Limit Breaks, and Abilities.

- Do note that the adaptation of this Discord Bot is not 100% the same as the one in Guardian Tales. Some sacrifices had to be made. Some parts are made simpler, including stats and abilities. For example, range and melee are unified, invincibility are removed (but other stats are increased to compensate), and many more.
- That is why, to see those changes, you can view it using the `book` command.
- Each hero has their own levels, to go from one level to another, you need to get 100 EXP.
- Each hero will start at `0` Limit Break. To go beyond the level cap, you need to use `limitbreak` command. Each Limit Break will grant to another 50 levels.
- For now, the only way to level up is by doing `arena`.

### Bug Fixes

- `rich` command not sorting properly is now fixed.