### PR TITLE
Release v1.4.1

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -91,7 +91,7 @@ class Bot(commands.Cog):
         db_ailie.disconnect()
 
         # Change upon version update
-        version = "1.4.0"
+        version = "1.4.1"
 
         # Mimic loading animation
         msg = await ctx.send(

--- a/cogs/pvp.py
+++ b/cogs/pvp.py
@@ -874,6 +874,12 @@ class PvP(commands.Cog):
                 + "or `global`."
             )
 
+        # If no one has trophy
+        if not guardian_with_trophy:
+            await ctx.send("No one has trophies.")
+            db_ailie.disconnect()
+            return
+
         # Display richest user in discord server
         guardian_with_trophy_sorted = sorted(guardian_with_trophy)[::-1]
         guardian_with_trophy = guardian_with_trophy_sorted[:10]


### PR DESCRIPTION
**Changelogs v1.4.0**

### Bug Fixes

- `rank` command sending error when no one has trophies yet.