### PR TITLE
Updated version info

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -187,7 +187,7 @@ class Bot(commands.Cog):
         db_ailie.disconnect()
 
         # Change upon version update
-        version = "1.4.4"
+        version = "1.5.0"
 
         # Mimic loading animation
         msg = await ctx.send(


### PR DESCRIPTION
- Every Guardian / User can farm EXP of their own.
- For every 100 EXP, Guardian will level up.
- The levels gained contributes to their heroes's stats.
- Guardian / User EXP can be obtained from `pat`, `race`, `gamble`, `share`, `arena`, and `summon` command.
- The current EXP and Level of a Guardian can be viewed from `profile` command.
- Can now be viewed using `inventory` command.
- `gems` and `trophy` command now gives a much more detailed output.