### PR TITLE
Updated version info

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -194,7 +194,7 @@ class Bot(commands.Cog):
         db_ailie.disconnect()
 
         # Change upon version update
-        version = "1.5.8"
+        version = "1.6.0"
 
         # Mimic loading animation
         msg = await ctx.send(


### PR DESCRIPTION
- Arena revamped. Player now are to enter their moves at the same time. The first one to enter their move will attack first.
- Dodge is now changed to Evade. The player will be able to dodge at 50% chance  for the next nearest attack. If no attack is done, then the buff will be wasted. Evade also have cooldown.
- Noxia's speed is nerfed from 50% to 40%.
- Hero's HP at arena is doubled.
- Hero stats calculation based on hero and guardian level is revamped.
- Ranking board algorithm is fixed.