### PR TITLE
Updated version info

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -191,7 +191,7 @@ class Bot(commands.Cog):
         db_ailie.disconnect()
 
         # Change upon version update
-        version = "1.6.2"
+        version = "1.6.3"
 
         # Mimic loading animation
         msg = await ctx.send(


### PR DESCRIPTION
- Fix unable to surrender when stunned in `arena`.
- Disable sharing to yourself via `share`.
- Fixed crash when dealing `CHAIN SKILL` in `arena` using a hero without damage from `CHAIN SKILL`.
- Shows HP on each round in `arena`.
- Format displays given from Ailie.