### PR TITLE
Updated version info

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -191,7 +191,7 @@ class Bot(commands.Cog):
         db_ailie.disconnect()
 
         # Change upon version update
-        version = "1.6.3"
+        version = "1.7.0"
 
         # Mimic loading animation
         msg = await ctx.send(


### PR DESCRIPTION
- Gives 100 EXP extra on each duplicate 3 Star heroes and Exclusive Weapons.
- `train` command to increase Hero EXP by `5` per command.